### PR TITLE
Fix get_revertpage_regexp

### DIFF
--- a/ukbot/site.py
+++ b/ukbot/site.py
@@ -63,6 +63,7 @@ class Site(mwclient.Site):
     def get_revertpage_regexp(self):
         msg = self.pages['MediaWiki:Revertpage'].text()
         msg = re.sub(r'\[\[[^\]]+\]\]', '.*?', msg)
+        msg = re.sub(r'(?i)\{\{PLURAL:\$\d\|(.+)\}\}', '(\1)', msg)
         return msg
 
     def match_prefix(self, prefix):


### PR DESCRIPTION
Because of an update in the underlying MediaWiki message, the message now contains pipes, which perform poorly when used in a regex. Instead convert the PLURAL syntax to regex-friendly (a|b|…) syntax.