### PR TITLE
Update SPARQL endpoint from WQS to Qlever and add prefixes

### DIFF
--- a/ukbot/filters.py
+++ b/ukbot/filters.py
@@ -762,7 +762,7 @@ class SparqlFilter(Filter):
         logger.info('Running SPARQL query: %s', querystring)
         try:
             response = requests_retry_session().get(
-                'https://query.wikidata.org/sparql',
+                'https://qlever.cs.uni-freiburg.de/api/wikidata',
                 params={
                     'query': querystring,
                 },
@@ -829,12 +829,47 @@ class SparqlFilter(Filter):
     def add_linked_articles(self, site, item_var):
         article_var = 'article19472065'  # "random string" to avoid matching anything in the subquery
         query = """
-            SELECT ?%(article)s
-            WHERE {
-              { %(query)s }
-              ?%(article)s schema:about ?%(item)s .
-              ?%(article)s schema:isPartOf <https://%(site)s/> .
-            }
+# https://www.mediawiki.org/wiki/Wikibase/Indexing/RDF_Dump_Format#Full_list_of_prefixes
+PREFIX bd: <http://www.bigdata.com/rdf#>
+PREFIX cc: <http://creativecommons.org/ns#>
+PREFIX dct: <http://purl.org/dc/terms/>
+PREFIX geo: <http://www.opengis.net/ont/geosparql#>
+PREFIX hint: <http://www.bigdata.com/queryHints#> 
+PREFIX ontolex: <http://www.w3.org/ns/lemon/ontolex#>
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX prov: <http://www.w3.org/ns/prov#>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX schema: <http://schema.org/>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+PREFIX p: <http://www.wikidata.org/prop/>
+PREFIX pq: <http://www.wikidata.org/prop/qualifier/>
+PREFIX pqn: <http://www.wikidata.org/prop/qualifier/value-normalized/>
+PREFIX pqv: <http://www.wikidata.org/prop/qualifier/value/>
+PREFIX pr: <http://www.wikidata.org/prop/reference/>
+PREFIX prn: <http://www.wikidata.org/prop/reference/value-normalized/>
+PREFIX prv: <http://www.wikidata.org/prop/reference/value/>
+PREFIX psv: <http://www.wikidata.org/prop/statement/value/>
+PREFIX ps: <http://www.wikidata.org/prop/statement/>
+PREFIX psn: <http://www.wikidata.org/prop/statement/value-normalized/>
+PREFIX wd: <http://www.wikidata.org/entity/>
+PREFIX wdata: <http://www.wikidata.org/wiki/Special:EntityData/>
+PREFIX wdno: <http://www.wikidata.org/prop/novalue/>
+PREFIX wdref: <http://www.wikidata.org/reference/>
+PREFIX wds: <http://www.wikidata.org/entity/statement/>
+PREFIX wdt: <http://www.wikidata.org/prop/direct/>
+PREFIX wdtn: <http://www.wikidata.org/prop/direct-normalized/>
+PREFIX wdv: <http://www.wikidata.org/value/>
+PREFIX wikibase: <http://wikiba.se/ontology#>
+
+SELECT ?%(article)s
+WHERE {
+    { %(query)s }
+    ?%(article)s schema:about ?%(item)s .
+    ?%(article)s schema:isPartOf <https://%(site)s/> .
+}
         """ % {
             'item': item_var,
             'article': article_var,


### PR DESCRIPTION
## Description

This will change SPARQL endpoint from WQS to QLever Wikidata endpoint and add Wikidata default prefixes as they are not by default defined in QLever.

Source for the list of prefixes
-  https://www.mediawiki.org/wiki/Wikibase/Indexing/RDF_Dump_Format#Full_list_of_prefixes

## QLever debug queries ##

Item list used in ukbot
- https://qlever.wikidata.dbis.rwth-aachen.de/wikidata/kAGvnJ

When QLever data has been updated
- https://qlever.dev/wikidata/Ge3kvC

<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [X] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore
- [ ] ⏩ Revert

## Related Tickets & Documents

<!-- 
Please use this format link issue numbers: Fixes #29
-->
Change fixes #29 where SPARQL queries are timeouting because WQS performance issues. 

## Tested?

- [X] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?

- [ ] 📜 README.md
- [ ] 📖 own file under the docs folder
- [ ] 🙅 no documentation needed

## [optional] Are there any pre- or post-deployment tasks we need to perform?

Change is currently running directly on production so local changes need to be reverted before doing pull

```
become ukbot
git diff
git checkout ukbot/filters.py
```


<!-- 
Write about changing templates or modules on-wiki in order to accomodate changes in this PR
-->