### PR TITLE
Use GET method for parsed comment assignment

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ukbot"
-version = "1.1.2"
+version = "1.1.3"
 description = "Wikipedia writing contest bot"
 authors = [
   { name = "Dan Michael O. Heggø", email = "danmichaelo@gmail.com" },

--- a/ukbot/user.py
+++ b/ukbot/user.py
@@ -205,7 +205,7 @@ class User:
                     rev = self.articles[article_key].revisions[apirev['revid']]
                     rev.parentid = apirev['parentid']
                     rev.size = apirev['size']
-                    rev.parsedcomment = apirev['parsedcomment']
+                    rev.parsedcomment = apirev.get('parsedcomment', '')
                     content = pydash.get(apirev, 'slots.main.*')
                     if content is not None:
                         rev.text = content


### PR DESCRIPTION
## Description
Before (crashes if field is absent):
`rev.parsedcomment = apirev['parsedcomment']`

After (safe fallback to empty string):
`rev.parsedcomment = apirev.get('parsedcomment', '')`

;UKBot log
![Screenshot 2026-04-03 at 11 55 47](https://github.com/user-attachments/assets/969253f9-868a-4a15-8543-fa20c8c23c29)

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [X] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore
- [ ] ⏩ Revert

## Related Tickets & Documents

<!-- 
Please use this format link issue numbers: Fixes #123
-->

## Tested?

- [ ] 👍 yes
- [X] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?

- [ ] 📜 README.md
- [ ] 📖 own file under the docs folder
- [X] 🙅 no documentation needed

## [optional] Are there any pre- or post-deployment tasks we need to perform?

<!-- 
Write about changing templates or modules on-wiki in order to accomodate changes in this PR
-->