### PR TITLE
added 'incubator.wikimedia.org', 'wikivoyage.org' to supported famili…

### DIFF
--- a/ukbot/rules/byte.py
+++ b/ukbot/rules/byte.py
@@ -10,7 +10,7 @@ class ByteRule(Rule):
 
     rule_name = 'byte'
 
-    @family('wikipedia.org', 'wikibooks.org')
+    @family('wikipedia.org', 'wikibooks.org', 'incubator.wikimedia.org', 'wikivoyage.org')
     def test(self, rev):
         bytes_added = rev.bytes
 

--- a/ukbot/rules/contrib.py
+++ b/ukbot/rules/contrib.py
@@ -10,7 +10,7 @@ class ContribRule(Rule):
 
     rule_name = 'contrib'
 
-    @family('wikipedia.org', 'wikibooks.org')
+    @family('wikipedia.org', 'wikibooks.org', 'incubator.wikimedia.org', 'wikivoyage.org')
     def test(self, rev):
         yield UserContribution(rev=rev, points=self.points, rule=self.rule,
                                description=_('contribution'))

--- a/ukbot/rules/external_link.py
+++ b/ukbot/rules/external_link.py
@@ -18,7 +18,7 @@ class ExternalLinkRule(Rule):
         txt = re.sub(r'<ref[^>]*>.*?</ref>', '', txt, flags=re.MULTILINE)
         return len(re.findall(r'(?<!\[)\[[^\[\] ]+ [^\[\]]+\](?!])', txt))
 
-    @family('wikipedia.org', 'wikibooks.org')
+    @family('wikipedia.org', 'wikibooks.org', 'incubator.wikimedia.org', 'wikivoyage.org')
     def test(self, rev):
         links_before = self.count_links(rev.parenttext)
         links_after = self.count_links(rev.text)

--- a/ukbot/rules/image.py
+++ b/ukbot/rules/image.py
@@ -91,7 +91,7 @@ class ImageRule(Rule):
 
         return credit
 
-    @family('wikipedia.org', 'wikibooks.org')
+    @family('wikipedia.org', 'wikibooks.org', 'incubator.wikimedia.org', 'wikivoyage.org')
     def test(self, rev):
         imgs_before = list(self.get_images(rev.parenttext))
         imgs_after = list(self.get_images(rev.text))

--- a/ukbot/rules/new.py
+++ b/ukbot/rules/new.py
@@ -10,7 +10,7 @@ class NewPageRule(Rule):
 
     rule_name = 'new'
 
-    @family('wikipedia.org', 'wikibooks.org')
+    @family('wikipedia.org', 'wikibooks.org', 'incubator.wikimedia.org', 'wikivoyage.org')
     def test(self, rev):
         if rev.new and not rev.redirect:
             yield UserContribution(rev=rev, points=self.points, rule=self, description=_('new page'))

--- a/ukbot/rules/qualified.py
+++ b/ukbot/rules/qualified.py
@@ -14,7 +14,7 @@ class QualiRule(Rule):
         Rule.__init__(self, sites, template, trans)
         self.articles_seen = set()
 
-    @family('wikipedia.org', 'wikibooks.org')
+    @family('wikipedia.org', 'wikibooks.org', 'incubator.wikimedia.org', 'wikivoyage.org')
     def test(self, rev):
         if rev.article().key not in self.articles_seen:
             self.articles_seen.add(rev.article().key)

--- a/ukbot/rules/redirect.py
+++ b/ukbot/rules/redirect.py
@@ -10,7 +10,7 @@ class RedirectRule(Rule):
 
     rule_name = 'redirect'
 
-    @family('wikipedia.org', 'wikibooks.org')
+    @family('wikipedia.org', 'wikibooks.org', 'incubator.wikimedia.org', 'wikivoyage.org')
     def test(self, rev):
         if rev.new and rev.redirect:
             yield UserContribution(rev=rev, points=self.points, rule=self, description=_('redirect'))

--- a/ukbot/rules/ref.py
+++ b/ukbot/rules/ref.py
@@ -61,7 +61,7 @@ class RefRule(Rule):
 
         return s1, r1
 
-    @family('wikipedia.org', 'wikibooks.org')
+    @family('wikipedia.org', 'wikibooks.org', 'incubator.wikimedia.org', 'wikivoyage.org')
     def test(self, rev):
 
         s1, r1 = self.count_sources(rev.parenttext)

--- a/ukbot/rules/rule.py
+++ b/ukbot/rules/rule.py
@@ -58,7 +58,7 @@ class BonusRule(Rule):
     def get_metric(self, rev):
         raise NotImplementedError()  # Should be overridden
 
-    @family('wikipedia.org', 'wikibooks.org')
+    @family('wikipedia.org', 'wikibooks.org', 'incubator.wikimedia.org', 'wikivoyage.org')
     def test(self, current_rev):
         total = 0
         this_rev = False

--- a/ukbot/rules/templateremoval.py
+++ b/ukbot/rules/templateremoval.py
@@ -72,7 +72,7 @@ class TemplateRemovalRule(Rule):
         ct = self.count_instances(template, rev.te_text())
         return pt - ct
 
-    @family('wikipedia.org', 'wikibooks.org')
+    @family('wikipedia.org', 'wikibooks.org', 'incubator.wikimedia.org', 'wikivoyage.org')
     def test(self, rev):
         if rev.redirect or rev.parentredirect:
             # skip redirects

--- a/ukbot/rules/word.py
+++ b/ukbot/rules/word.py
@@ -10,7 +10,7 @@ class WordRule(Rule):
 
     rule_name = 'word'
 
-    @family('wikipedia.org', 'wikibooks.org')
+    @family('wikipedia.org', 'wikibooks.org', 'incubator.wikimedia.org', 'wikivoyage.org')
     def test(self, rev):
         words_added = rev.words
 


### PR DESCRIPTION
Change adds incubator and *.wikivoyage.org to supported wikifamilies in points calculation rules. Change is tested  in Incubator. This is points part change for https://github.com/WikimediaNorge/UKBot/issues/99

## Description

<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->

## What type of PR is this? (check all applicable)

- [X] 🍕 Feature

## Related Tickets & Documents

<!-- 
Please use this format link issue numbers: Fixes #123
-->

## Tested?

- [X] 👍 yes

## Added to documentation?

- [X] 🙅 no documentation needed

