### PR TITLE
Feat add endpoint and pages options to sparql filter

### DIFF
--- a/config/config.se.yml
+++ b/config/config.se.yml
@@ -101,6 +101,7 @@ templates:
         ignore: ignore
         sparql: sparql  # as in {{ ukb criterion | sparql }}
         query: query    # as in {{ ukb criterion | sparql | query=... }}
+        endpoint: endpoint
 pages:
     catignore: Käyttäjä:UKBot/cat-ignore
     base: Wikipedia:Elokuun_kuvitustalkoot/

--- a/config/sites/cawiki.yml
+++ b/config/sites/cawiki.yml
@@ -99,6 +99,7 @@ templates:
                 name: sparql  # as in {{ ukb criterion | sparql }}
                 params:
                     query: query    # as in {{ ukb criterion | sparql | query=... }}
+                    endpoint: endpoint
 awards:
     blava: { file: Article blue.svg, winner: true }
     blau: { file: Article blue.svg, winner: true }

--- a/config/sites/cawiki.yml
+++ b/config/sites/cawiki.yml
@@ -100,6 +100,7 @@ templates:
                 params:
                     query: query    # as in {{ ukb criterion | sparql | query=... }}
                     endpoint: endpoint
+                    mode: mode
 awards:
     blava: { file: Article blue.svg, winner: true }
     blau: { file: Article blue.svg, winner: true }

--- a/config/sites/enwiki.yml
+++ b/config/sites/enwiki.yml
@@ -97,6 +97,7 @@ templates:
                 name: sparql  # as in {{ ukb criterion | sparql }}
                 params:
                     query: query    # as in {{ ukb criterion | sparql | query=... }}
+                    endpoint: endpoint
 awards:
     blå: { file: Article blue.svg, winner: true }
     rød: { file: Article red.svg, winner: true }

--- a/config/sites/enwiki.yml
+++ b/config/sites/enwiki.yml
@@ -98,6 +98,7 @@ templates:
                 params:
                     query: query    # as in {{ ukb criterion | sparql | query=... }}
                     endpoint: endpoint
+                    mode: mode
 awards:
     blå: { file: Article blue.svg, winner: true }
     rød: { file: Article red.svg, winner: true }

--- a/config/sites/eswiki.yml
+++ b/config/sites/eswiki.yml
@@ -95,4 +95,5 @@ templates:
                 params:
                     query: query # as in {{ ukb criterion | sparql | query=... }}
                     endpoint: endpoint
+                    mode: mode
 

--- a/config/sites/eswiki.yml
+++ b/config/sites/eswiki.yml
@@ -94,3 +94,5 @@ templates:
                 name: sparql # as in {{ ukb criterion | sparql }}
                 params:
                     query: query # as in {{ ukb criterion | sparql | query=... }}
+                    endpoint: endpoint
+

--- a/config/sites/euwiki.yml
+++ b/config/sites/euwiki.yml
@@ -98,3 +98,4 @@ templates:
                 params:
                     query: query    # as in {{ ukb criterion | sparql | query=... }}
                     endpoint: endpoint
+                    mode: mode

--- a/config/sites/euwiki.yml
+++ b/config/sites/euwiki.yml
@@ -97,3 +97,4 @@ templates:
                 name: sparql  # as in {{ ukb criterion | sparql }}
                 params:
                     query: query    # as in {{ ukb criterion | sparql | query=... }}
+                    endpoint: endpoint

--- a/config/sites/fiwiki.yml
+++ b/config/sites/fiwiki.yml
@@ -99,3 +99,5 @@ templates:
                 params:
                     query: query    # as in {{ ukb criterion | sparql | query=... }}
                     endpoint: endpoint
+                    mode: mode
+

--- a/config/sites/fiwiki.yml
+++ b/config/sites/fiwiki.yml
@@ -98,3 +98,4 @@ templates:
                 name: sparql  # as in {{ ukb criterion | sparql }}
                 params:
                     query: query    # as in {{ ukb criterion | sparql | query=... }}
+                    endpoint: endpoint

--- a/config/sites/glwiki.yml
+++ b/config/sites/glwiki.yml
@@ -94,3 +94,4 @@ templates:
                 name: sparql # as in {{ ukb criterion | sparql }}
                 params:
                     query: query # as in {{ ukb criterion | sparql | query=... }}
+                    endpoint: endpoint

--- a/config/sites/glwiki.yml
+++ b/config/sites/glwiki.yml
@@ -95,3 +95,4 @@ templates:
                 params:
                     query: query # as in {{ ukb criterion | sparql | query=... }}
                     endpoint: endpoint
+                    mode: mode

--- a/config/sites/nowiki.yml
+++ b/config/sites/nowiki.yml
@@ -105,6 +105,7 @@ templates:
                 params:
                     query: spørring    # as in {{ ukb criterion | sparql | query=... }}
                     endpoint: endpoint
+                    mode: mode
 awards:
     blå: { file: Article blue.svg, winner: true }
     rød: { file: Article red.svg, winner: true }

--- a/config/sites/nowiki.yml
+++ b/config/sites/nowiki.yml
@@ -104,6 +104,7 @@ templates:
                 name: sparql  # as in {{ ukb criterion | sparql }}
                 params:
                     query: spørring    # as in {{ ukb criterion | sparql | query=... }}
+                    endpoint: endpoint
 awards:
     blå: { file: Article blue.svg, winner: true }
     rød: { file: Article red.svg, winner: true }

--- a/test/test_filters.py
+++ b/test/test_filters.py
@@ -234,6 +234,33 @@ class TestSparqlFilter(TestCase):
         assert result['var'] == 'item'
         assert result['rows'] == ['http://www.wikidata.org/entity/Q1']
 
+    @patch('ukbot.filters.SparqlFilter.fetch')
+    def test_add_pages_filters_to_contest_wikis(self, fetch_mock):
+        sites = {'en.wikipedia.org': Mock(), 'fi.wikipedia.org': Mock(), '*.wikivoyage.org': Mock()}
+        sparql_filter = SparqlFilter(
+            sites=sites,
+            query='SELECT ?article WHERE { ?article ?p ?o . }',
+            mode='pages',
+        )
+        sparql_filter.do_query = Mock(return_value={
+            'rows': [
+                'https://en.wikipedia.org/wiki/Foo_bar',
+                'http://fi.wikipedia.org/wiki/Baz',
+                'https://fi.wikivoyage.org/wiki/Helsinki',
+                'https://en.wikipedia.org/w/index.php?title=Ignored',
+                'https://example.org/wiki/Outside',
+                'not a url',
+            ],
+        })
+
+        sparql_filter.add_pages()
+
+        assert sparql_filter.page_keys == {
+            'en.wikipedia.org:Foo bar',
+            'fi.wikipedia.org:Baz',
+            'fi.wikivoyage.org:Helsinki',
+        }
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_filters.py
+++ b/test/test_filters.py
@@ -2,14 +2,14 @@
 import re
 from collections import OrderedDict
 import unittest
-from mock import Mock
+from mock import Mock, patch
 from unittest import TestCase
 
 from faker import Faker
 from mwclient.page import Page
 
 from ukbot.article import Article
-from ukbot.filters import CatFilter
+from ukbot.filters import CatFilter, SparqlFilter
 from ukbot.site import Site
 from ukbot.sites import SiteManager
 
@@ -120,6 +120,119 @@ class TestCatFilter(TestCase):
 
         assert self.filter_and_return_keys(**kwargs(2)) == []
         assert self.filter_and_return_keys(**kwargs(3)) == [dummy.a_key(0)]
+
+class TestSparqlFilter(TestCase):
+
+    @patch('ukbot.filters.SparqlFilter.fetch')
+    def test_make_reads_endpoint_param(self, fetch_mock):
+        tpl = Mock()
+        tpl.sites = Mock()
+        tpl.has_param = lambda name: name in ['query', 'endpoint']
+        tpl.get_raw_param = lambda name: {
+            'query': 'SELECT ?item WHERE { ?item wdt:P31 wd:Q5 . }',
+            'endpoint': 'https://example.org/sparql',
+        }[name]
+
+        cfg = {
+            'params': {
+                'query': 'query',
+                'endpoint': 'endpoint',
+            },
+        }
+
+        sparql_filter = SparqlFilter.make(tpl=tpl, cfg=cfg)
+
+        assert sparql_filter.endpoint == 'https://example.org/sparql'
+        fetch_mock.assert_called_once()
+
+    @patch('ukbot.filters.SparqlFilter.fetch')
+    def test_make_uses_default_endpoint_when_missing(self, fetch_mock):
+        tpl = Mock()
+        tpl.sites = Mock()
+        tpl.has_param = lambda name: name == 'query'
+        tpl.get_raw_param = lambda name: {
+            'query': 'SELECT ?item WHERE { ?item wdt:P31 wd:Q5 . }',
+        }[name]
+
+        cfg = {
+            'params': {
+                'query': 'query',
+                'endpoint': 'endpoint',
+            },
+        }
+
+        sparql_filter = SparqlFilter.make(tpl=tpl, cfg=cfg)
+
+        assert sparql_filter.endpoint == 'https://query.wikidata.org/sparql'
+        fetch_mock.assert_called_once()
+
+    @patch('ukbot.filters.SparqlFilter.fetch')
+    def test_make_reads_mode_param(self, fetch_mock):
+        tpl = Mock()
+        tpl.sites = Mock()
+        tpl.has_param = lambda name: name in ['query', 'mode']
+        tpl.get_raw_param = lambda name: {
+            'query': 'SELECT ?article WHERE { ?article ?p ?o . }',
+            'mode': 'pages',
+        }[name]
+
+        cfg = {
+            'params': {
+                'query': 'query',
+                'mode': 'mode',
+            },
+        }
+
+        sparql_filter = SparqlFilter.make(tpl=tpl, cfg=cfg)
+
+        assert sparql_filter.mode == 'pages'
+        fetch_mock.assert_called_once()
+
+    @patch('ukbot.filters.SparqlFilter.fetch')
+    def test_make_rejects_non_http_endpoint(self, fetch_mock):
+        tpl = Mock()
+        tpl.sites = Mock()
+        tpl.has_param = lambda name: name in ['query', 'endpoint']
+        tpl.get_raw_param = lambda name: {
+            'query': 'SELECT ?item WHERE { ?item wdt:P31 wd:Q5 . }',
+            'endpoint': 'ftp://example.org/sparql',
+        }[name]
+
+        cfg = {
+            'params': {
+                'query': 'query',
+                'endpoint': 'endpoint',
+            },
+        }
+
+        with self.assertRaises(ValueError):
+            SparqlFilter.make(tpl=tpl, cfg=cfg)
+        fetch_mock.assert_not_called()
+
+    @patch('ukbot.filters.requests_retry_session')
+    @patch('ukbot.filters.SparqlFilter.fetch')
+    def test_do_query_uses_custom_endpoint(self, fetch_mock, requests_retry_session_mock):
+        response = Mock()
+        response.ok = True
+        response.headers = {}
+        response.json.return_value = {
+            'head': {'vars': ['item']},
+            'results': {'bindings': [{'item': {'value': 'http://www.wikidata.org/entity/Q1'}}]},
+        }
+        requests_retry_session_mock.return_value.get.return_value = response
+
+        sparql_filter = SparqlFilter(
+            sites=Mock(),
+            query='SELECT ?item WHERE { ?item wdt:P31 wd:Q5 . }',
+            endpoint='https://example.org/sparql',
+        )
+        result = sparql_filter.do_query('SELECT ?item WHERE { ?item wdt:P31 wd:Q5 . }')
+
+        requests_retry_session_mock.return_value.get.assert_called_once()
+        call_args = requests_retry_session_mock.return_value.get.call_args
+        assert call_args[0][0] == 'https://example.org/sparql'
+        assert result['var'] == 'item'
+        assert result['rows'] == ['http://www.wikidata.org/entity/Q1']
 
 
 if __name__ == '__main__':

--- a/ukbot/filters.py
+++ b/ukbot/filters.py
@@ -740,29 +740,38 @@ class SparqlFilter(Filter):
 
     @classmethod
     def make(cls, tpl, cfg, **kwargs):
-        if not tpl.has_param('query'):
+        query_param = cfg['params']['query']
+        if not tpl.has_param(query_param):
             raise RuntimeError(_('No "%s" parameter given') % cfg['params']['query'])
+
+        endpoint_param = cfg['params'].get('endpoint')
         params = {
-            'query': tpl.get_raw_param('query'),
+            'query': tpl.get_raw_param(query_param),
             'sites': tpl.sites,
+            'endpoint': tpl.get_raw_param(endpoint_param) if endpoint_param and tpl.has_param(endpoint_param) else None,
         }
         return cls(**params)
 
-    def __init__(self, sites, query):
+    def __init__(self, sites, query, endpoint=None):
         """
         Args:
             sites (SiteManager): References to the sites part of this contest
             query (str): The SPARQL query
+            endpoint (str): SPARQL endpoint URL. Defaults to Wikidata Query Service.
         """
         Filter.__init__(self, sites)
         self.query = query
+        self.endpoint = endpoint or 'https://query.wikidata.org/sparql'
+        endpoint_scheme = urllib.parse.urlparse(self.endpoint).scheme.lower()
+        if endpoint_scheme not in ['http', 'https']:
+            raise ValueError('Invalid sparql endpoint scheme: %s' % endpoint_scheme)
         self.fetch()
 
     def do_query(self, querystring):
-        logger.info('Running SPARQL query: %s', querystring)
+        logger.info('Running SPARQL query at %s: %s', self.endpoint, querystring)
         try:
             response = requests_retry_session().get(
-                'https://query.wikidata.org/sparql',
+                self.endpoint,
                 params={
                     'query': querystring,
                 },

--- a/ukbot/filters.py
+++ b/ukbot/filters.py
@@ -3,6 +3,7 @@
 import sys
 import re
 from copy import copy
+from fnmatch import fnmatch
 
 from more_itertools import first
 import logging
@@ -745,19 +746,22 @@ class SparqlFilter(Filter):
             raise RuntimeError(_('No "%s" parameter given') % cfg['params']['query'])
 
         endpoint_param = cfg['params'].get('endpoint')
+        mode_param = cfg['params'].get('mode', 'mode')
         params = {
             'query': tpl.get_raw_param(query_param),
             'sites': tpl.sites,
             'endpoint': tpl.get_raw_param(endpoint_param) if endpoint_param and tpl.has_param(endpoint_param) else None,
+            'mode': tpl.get_raw_param(mode_param) if tpl.has_param(mode_param) else 'items',
         }
         return cls(**params)
 
-    def __init__(self, sites, query, endpoint=None):
+    def __init__(self, sites, query, endpoint=None, mode='items'):
         """
         Args:
             sites (SiteManager): References to the sites part of this contest
             query (str): The SPARQL query
             endpoint (str): SPARQL endpoint URL. Defaults to Wikidata Query Service.
+            mode (str): "items" (default) or "pages"
         """
         Filter.__init__(self, sites)
         self.query = query
@@ -765,6 +769,9 @@ class SparqlFilter(Filter):
         endpoint_scheme = urllib.parse.urlparse(self.endpoint).scheme.lower()
         if endpoint_scheme not in ['http', 'https']:
             raise ValueError('Invalid sparql endpoint scheme: %s' % endpoint_scheme)
+        if mode not in ['items', 'pages']:
+            raise ValueError('Invalid sparql mode: %s' % mode)
+        self.mode = mode
         self.fetch()
 
     def do_query(self, querystring):
@@ -813,6 +820,10 @@ class SparqlFilter(Filter):
         logger.debug('SparqlFilter: %s', self.query)
 
         item_var = 'item'
+        if self.mode == 'pages':
+            self.add_pages()
+            logger.info('SparqlFilter: Initialized with %d articles', len(self.page_keys))
+            return
 
         # Implementation notes:
         # - When the contest includes multiple sites, we do one query per site. I tried using
@@ -834,6 +845,25 @@ class SparqlFilter(Filter):
             logger.info('SparqlFilter: Got %d results for %s in %.1f secs', s1, site, t1)
 
         logger.info('SparqlFilter: Initialized with %d articles', len(self.page_keys))
+
+    def add_pages(self):
+        allowed_hosts = list(self.sites.keys())
+
+        for res in self.do_query(self.query)['rows']:
+            parsed = urllib.parse.urlparse(res)
+            if parsed.scheme not in ['http', 'https']:
+                continue
+            hostname = parsed.hostname or ''
+            if not any(fnmatch(hostname, pattern) for pattern in allowed_hosts):
+                continue
+            if not parsed.path.startswith('/wiki/'):
+                continue
+
+            article = urllib.parse.unquote(parsed.path[len('/wiki/'):]).replace('_', ' ')
+            if article == '':
+                continue
+            page_key = '%s:%s' % (hostname, article)
+            self.page_keys.add(page_key)
 
     def add_linked_articles(self, site, item_var):
         article_var = 'article19472065'  # "random string" to avoid matching anything in the subquery


### PR DESCRIPTION
## Description

This will add support for using full SELECTs and defining article URI:s directly in SPARQL in _?article_ variable. 

Example below

`{{Viikon kilpailu kriteerit|sparql|mode=pages|query=SELECT ?article WHERE {  hint:Query hint:optimizer "None" . SERVICE <https://qlever.cs.uni-freiburg.de/api/wikidata> { SERVICE <https://sparqlbridge.toolforge.org/newpages/sparql/wiki=fi,smn,olo,se,incubator&include_edited_pages=1&timestamp=20260331&user_list_page=w:fi:Wikiprojekti:Punaisten_linkkien_naiset/2026>  { SELECT ?article ?item  WHERE { ?article <http://schema.org/about> ?item . } GROUP BY ?article ?item } } ?item wdt:P21 ?gender . FILTER (?gender NOT IN (wd:Q6581097, wd:Q44148, wd:Q2449503)) } GROUP BY ?article  }} `

The endpoint definition will work like this

`{{Viikon kilpailu kriteerit|sparql|endpoint=https://query-main.wikidata.org/sparqlmode=pages|query=?item wdt:P31 wd:Q146. }} `

### Howto test
`ukbot --page Wikiprojekti:Punaisten_linkkien_naiset/2026-test --simulate config/config.fi-pln.yml`

Note: Qlever can fail with Status Code=503  and it is not related to our code

<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->
https://github.com/WikimediaNorge/UKBot/issues/104

## What type of PR is this? (check all applicable)

- [X] 🍕 Feature

## Related Tickets & Documents

<!-- 
Please use this format link issue numbers: Fixes #123
-->

## Tested?

- [X] 👍 yes

## Added to documentation?

- [X] 🙅 no documentation needed

## [optional] Are there any pre- or post-deployment tasks we need to perform?

<!-- 
Write about changing templates or modules on-wiki in order to accomodate changes in this PR
-->