### PR TITLE
Fix exception handling for XML parsing errors

### DIFF
--- a/ukbot/rules/ref.py
+++ b/ukbot/rules/ref.py
@@ -43,7 +43,7 @@ class RefRule(Rule):
                 else:
                     s1 += 1
             del xml
-        except lxml.etree.XMLSyntaxError:
+        except lxml.etree.LxmlError:
             s1 = 0
             r1 = 0
 


### PR DESCRIPTION
change lxml.etree.XMLSyntaxError to wider lxml.etree.LxmlError exception for catching all XML parsing errors

## Description

This PR fixes the https://github.com/WikimediaNorge/UKBot/issues/113
<!-- 
Please do not leave this blank 
This PR fixes the [feature/bug/etc]. 
-->

## What type of PR is this? (check all applicable)

- [X] 🐛 Bug Fix

## Tested?

- [X] 👍 yes

## Added to documentation?

- [X] 🙅 no documentation needed

